### PR TITLE
fix: tv remote handler failing firetv build

### DIFF
--- a/packages/harness/renative.json
+++ b/packages/harness/renative.json
@@ -84,7 +84,25 @@
                     "io.flexn.sdk.TvRemoteHandlerModule",
                     "android.view.KeyEvent;"
                 ],
-                "activityMethods": []
+                "activityMethods": [
+                    "override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event, \"up\");",
+                    "return super.onKeyUp(keyCode, event)",
+                    "}",
+                    "override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "   TvRemoteHandlerModule.getInstance().onKeyEvent(event,  \"longPress\");",
+                    "    return super.onKeyLongPress(keyCode, event)",
+                    "}",
+                    "override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "if(keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_UP || keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {",
+                    "event?.startTracking();",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event,\"down\");",
+                    "return true;",
+                    "}",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event, \"down\");",
+                    "return super.onKeyDown(keyCode, event)",
+                    "}"
+                ]
             }
         },
         "@rnv/renative": "source:flexn",

--- a/packages/template/renative.json
+++ b/packages/template/renative.json
@@ -98,11 +98,22 @@
                     "android.view.KeyEvent;"
                 ],
                 "activityMethods": [
-                    "override fun dispatchKeyEvent(event: KeyEvent): Boolean {",
-                    "   if (event.action == KeyEvent.ACTION_DOWN || event.action == KeyEvent.ACTION_UP) {",
-                    "       TvRemoteHandlerModule.getInstance().onKeyEvent(event);",
-                    "   }",
-                    "   return super.dispatchKeyEvent(event);",
+                    "override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event, \"up\");",
+                    "return super.onKeyUp(keyCode, event)",
+                    "}",
+                    "override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "   TvRemoteHandlerModule.getInstance().onKeyEvent(event,  \"longPress\");",
+                    "    return super.onKeyLongPress(keyCode, event)",
+                    "}",
+                    "override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {",
+                    "if(keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_UP || keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {",
+                    "event?.startTracking();",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event,\"down\");",
+                    "return true;",
+                    "}",
+                    "TvRemoteHandlerModule.getInstance().onKeyEvent(event, \"down\");",
+                    "return super.onKeyDown(keyCode, event)",
                     "}"
                 ]
             }


### PR DESCRIPTION
Fixes #24.
Tested with flexn template on Android API 22, 28.
Harness not tested due to it currently throwing "Super expression must either be null or a function" error.