### PR TITLE
Chore: add slack pinger when e2e fails

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -12,8 +12,6 @@ on:
 jobs:
     deploy-docs-preview:
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Run Docs Deploy Preview

--- a/.github/workflows/deploy-docs-prod.yml
+++ b/.github/workflows/deploy-docs-prod.yml
@@ -15,8 +15,6 @@ on:
 jobs:
     deploy-docs-prod:
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Run Docs Deploy Prod

--- a/.github/workflows/e2e-harness-android.yml
+++ b/.github/workflows/e2e-harness-android.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-android:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-android' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos, intel]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-android.yml
+++ b/.github/workflows/e2e-harness-android.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Harness App Android
               run: |
                   yarn e2e-harness-android
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-android.yml
+++ b/.github/workflows/e2e-harness-android.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Harness App Android
               run: |
                   yarn e2e-harness-android
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-androidtv.yml
+++ b/.github/workflows/e2e-harness-androidtv.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Harness App AndroidTV
               run: |
                   yarn e2e-harness-androidtv
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-androidtv.yml
+++ b/.github/workflows/e2e-harness-androidtv.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Harness App AndroidTV
               run: |
                   yarn e2e-harness-androidtv
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Harness AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-androidtv.yml
+++ b/.github/workflows/e2e-harness-androidtv.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-androidtv:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-androidtv' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos, intel]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-ios.yml
+++ b/.github/workflows/e2e-harness-ios.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Harness App iOS
               run: |
                   yarn e2e-harness-ios
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-ios.yml
+++ b/.github/workflows/e2e-harness-ios.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Harness App iOS
               run: |
                   yarn e2e-harness-ios
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Harness iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-ios.yml
+++ b/.github/workflows/e2e-harness-ios.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-ios:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-ios' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-macos.yml
+++ b/.github/workflows/e2e-harness-macos.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Harness App macOS
               run: |
                   yarn e2e-harness-macos
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-macos.yml
+++ b/.github/workflows/e2e-harness-macos.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-macos:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-macos' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-macos.yml
+++ b/.github/workflows/e2e-harness-macos.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Harness App macOS
               run: |
                   yarn e2e-harness-macos
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-tvos.yml
+++ b/.github/workflows/e2e-harness-tvos.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Harness App tvOS
               run: |
                   yarn e2e-harness-tvos
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-tvos.yml
+++ b/.github/workflows/e2e-harness-tvos.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-tvos:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-tvos' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-tvos.yml
+++ b/.github/workflows/e2e-harness-tvos.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Harness App tvOS
               run: |
                   yarn e2e-harness-tvos
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            - name: Post message to Slack via Webhook
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+              # if: ${{ github.event_name == 'push' && failure() }}
+              # uses: slackapi/slack-github-action@v1.23.0
+              # with:
+              #     payload: |
+              #         {
+              #           "text": "<!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+              #           "blocks": [
+              #             {
+              #               "type": "section",
+              #               "text": {
+              #                 "type": "mrkdwn",
+              #                 "text": "<!here> *Harness tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+              #               }
+              #             }
+              #           ]
+              #         }
+              # env:
+              #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-web.yml
+++ b/.github/workflows/e2e-harness-web.yml
@@ -31,18 +31,18 @@ jobs:
               run: |
                   yarn e2e-harness-web
             - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
+              if: ${{ failure() }}
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   payload: |
                       {
-                        "text": " <!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "text": " test ",
                         "blocks": [
                           {
                             "type": "section",
                             "text": {
                               "type": "mrkdwn",
-                              "text": " <!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                              "text": " test "
                             }
                           }
                         ]

--- a/.github/workflows/e2e-harness-web.yml
+++ b/.github/workflows/e2e-harness-web.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-harness-web:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-harness-web' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-harness-web.yml
+++ b/.github/workflows/e2e-harness-web.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Harness App Web
               run: |
                   yarn e2e-harness-web
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-harness-web.yml
+++ b/.github/workflows/e2e-harness-web.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Harness App Web
               run: |
                   yarn e2e-harness-web
-            - name: Post message to Slack via webhook
-              if: ${{ failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " test ",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " test "
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to harness builds not working and minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Harness Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-android.yml
+++ b/.github/workflows/e2e-template-android.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-android:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-android' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos, intel]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-template-android.yml
+++ b/.github/workflows/e2e-template-android.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Template App Android
               run: |
                   yarn e2e-template-android
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-android.yml
+++ b/.github/workflows/e2e-template-android.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Template App Android
               run: |
                   yarn e2e-template-android
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template Android e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-androidtv.yml
+++ b/.github/workflows/e2e-template-androidtv.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Template App AndroidTV
               run: |
                   yarn e2e-template-androidtv
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-androidtv.yml
+++ b/.github/workflows/e2e-template-androidtv.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-androidtv:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-androidtv' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos, intel]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-template-androidtv.yml
+++ b/.github/workflows/e2e-template-androidtv.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Template App AndroidTV
               run: |
                   yarn e2e-template-androidtv
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template AndroidTV e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-ios.yml
+++ b/.github/workflows/e2e-template-ios.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Template App iOS
               run: |
                   yarn e2e-template-ios
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-ios.yml
+++ b/.github/workflows/e2e-template-ios.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Template App iOS
               run: |
                   yarn e2e-template-ios
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template iOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-ios.yml
+++ b/.github/workflows/e2e-template-ios.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-ios:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-ios' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-template-macos.yml
+++ b/.github/workflows/e2e-template-macos.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Template App macOS
               run: |
                   yarn e2e-template-macos
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-macos.yml
+++ b/.github/workflows/e2e-template-macos.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-macos:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-macos' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-template-macos.yml
+++ b/.github/workflows/e2e-template-macos.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Template App macOS
               run: |
                   yarn e2e-template-macos
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template macOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-tvos.yml
+++ b/.github/workflows/e2e-template-tvos.yml
@@ -31,3 +31,22 @@ jobs:
             - name: E2E Template App tvOS
               run: |
                   yarn e2e-template-tvos
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-tvos.yml
+++ b/.github/workflows/e2e-template-tvos.yml
@@ -31,22 +31,23 @@ jobs:
             - name: E2E Template App tvOS
               run: |
                   yarn e2e-template-tvos
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template tvOS e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-tvos.yml
+++ b/.github/workflows/e2e-template-tvos.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-tvos:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-tvos' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/.github/workflows/e2e-template-web.yml
+++ b/.github/workflows/e2e-template-web.yml
@@ -30,22 +30,23 @@ jobs:
             - name: E2E Template App Web
               run: |
                   yarn e2e-template-web
-            - name: Post message to Slack via webhook
-              if: ${{ github.event_name == 'push' && failure() }}
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  payload: |
-                      {
-                        "text": " <!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
-                        "blocks": [
-                          {
-                            "type": "section",
-                            "text": {
-                              "type": "mrkdwn",
-                              "text": " <!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
-                            }
-                          }
-                        ]
-                      }
-              env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            # Commented because e2e tests would fail due to minion issues
+            # - name: Post message to Slack via Webhook
+            #   if: ${{ github.event_name == 'push' && failure() }}
+            #   uses: slackapi/slack-github-action@v1.23.0
+            #   with:
+            #       payload: |
+            #           {
+            #             "text": "<!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+            #             "blocks": [
+            #               {
+            #                 "type": "section",
+            #                 "text": {
+            #                   "type": "mrkdwn",
+            #                   "text": "<!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+            #                 }
+            #               }
+            #             ]
+            #           }
+            #   env:
+            #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-web.yml
+++ b/.github/workflows/e2e-template-web.yml
@@ -30,3 +30,22 @@ jobs:
             - name: E2E Template App Web
               run: |
                   yarn e2e-template-web
+            - name: Post message to Slack via webhook
+              if: ${{ github.event_name == 'push' && failure() }}
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  payload: |
+                      {
+                        "text": " <!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": " <!here> *Template Web e2e tests FAILED after* <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|push> :alert:"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e-template-web.yml
+++ b/.github/workflows/e2e-template-web.yml
@@ -19,8 +19,6 @@ jobs:
     e2e-template-web:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.label.name == 'e2e-template-web' || github.event.label.name == 'e2e' }}
         runs-on: [self-hosted, macos]
-        env:
-            GHP_AUTH_TOKEN: ${{ secrets.GHP_AUTH_TOKEN }}
         steps:
             - uses: actions/checkout@v2
             - name: Setup

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "e2e-harness-tvos": "cd packages/harness && npx rnv build -p tvos -s test --packageManager yarn --ci && yarn e2e:tvos",
         "e2e-harness-androidtv": "cd packages/harness && npx rnv build -p androidtv -s test --packageManager yarn --ci && yarn e2e:androidtv",
         "e2e-harness-macos": "cd packages/harness && npx rnv build -p macos -s test --packageManager yarn --ci && yarn e2e:macos",
-        "e2e-harness-web": "cd packages/harness && npx rnv start -p web -s test --packageManager yarn & sleep 60 && cd packages/harness --ci && yarn e2e:web && kill $(lsof -t -i:8080)",
+        "e2e-harness-web": "cd packages/harness && npx rnv start -p web -s test --packageManager yarn --ci & sleep 60 && cd packages/harness && yarn e2e:web && kill $(lsof -t -i:8080)",
         "e2e-template-ios": "cd packages/template && npx rnv build -p ios -s test -c template --packageManager yarn --ci && yarn e2e:ios",
         "e2e-template-android": "cd packages/template && npx rnv build -p android -s test -c template --packageManager yarn --ci && yarn e2e:android",
         "e2e-template-tvos": "cd packages/template && npx rnv build -p tvos -s test -c template --packageManager yarn --ci && yarn e2e:tvos",


### PR DESCRIPTION
- Removed gh token reference in actions because it is not needed
- Fixed harness web e2e script
- Added slack pinger to e2e tests, was tested and then commented out due to minion issues and harness build issues
https://github.com/slackapi/slack-github-action